### PR TITLE
Fix wrong case for Dpn\DpnGlossary\Domain\Repository\TermRepository.

### DIFF
--- a/Classes/Service/WrapperService.php
+++ b/Classes/Service/WrapperService.php
@@ -58,7 +58,7 @@ class WrapperService implements \TYPO3\CMS\Core\SingletonInterface {
 			// Get Query Settings
 			$querySettings = $objectManager->get('TYPO3\CMS\Extbase\Persistence\Generic\QuerySettingsInterface');
 			// Get termRepository
-			$termRepository = $objectManager->get('Dpn\DpnGlossary\Domain\Repository\termRepository');
+			$termRepository = $objectManager->get('Dpn\DpnGlossary\Domain\Repository\TermRepository');
 			// Get Typoscript Configuration
 			$this->tsConfig = $configurationManager->getConfiguration(\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
 			// Reduce TS config to plugin and format the array


### PR DESCRIPTION
The class TermRepository is refereed to with the first letter in lower-case while the definition user an upper-case first letter. This fixes an error with latest TYPO-6.1:

`Could not analyse class:Dpn\DpnGlossary\Domain\Repository\termRepository maybe not loaded or no autoloader`
