### PR TITLE
[BUGFIX] Fixed usage of nested stdWrap properties

### DIFF
--- a/Classes/ViewHelpers/Widget/Controller/PaginateController.php
+++ b/Classes/ViewHelpers/Widget/Controller/PaginateController.php
@@ -105,7 +105,12 @@ class PaginateController extends AbstractWidgetController {
 
 		// Apply stdWrap
 		if (is_array($this->configuration['characters'])) {
-			$this->configuration['characters'] = $cObj->cObjGetSingle($this->configuration['characters']['_typoScriptNodeValue'], $this->configuration['characters']);
+			/** @var TYPO3\CMS\Extbase\Service\TypoScriptService */
+			$tsService = $this->objectManager->get('TYPO3\CMS\Extbase\Service\TypoScriptService');
+
+			// It's required to convert the "new" array to dot notation one before we can use `cObjGetSingle`
+			$this->configuration['characters'] = $tsService->convertPlainArrayToTypoScriptArray($this->configuration['characters']);
+			$this->configuration['characters'] = $this->cObj->cObjGetSingle($this->configuration['characters']['_typoScriptNodeValue'], $this->configuration['characters']);
 		}
 
 		$this->characters = explode(',', $this->configuration['characters']);


### PR DESCRIPTION
Fixed a bug when using nested properties like:

```
plugin.tx_dpnglossary.settings.pagination {
	characters = TEXT
	characters {
		value = A,B,C
		stdWrap {
			wrap = |,D
		}
	}
}
```
