### PR TITLE
Use new way of registering wizard in TCA

### DIFF
--- a/Configuration/TCA/Description.php
+++ b/Configuration/TCA/Description.php
@@ -70,7 +70,9 @@ $TCA['tx_dpnglossary_domain_model_description'] = array(
 						'icon' => 'wizard_rte2.gif',
 						'notNewRecords' => 1,
 						'RTEonly' => 1,
-						'script' => 'wizard_rte.php',
+						'module' => array(
+							'name' => 'wizard_rte'
+						),
 						'title' => 'LLL:EXT:cms/locallang_ttc.xlf:bodytext.W.RTE',
 						'type' => 'script',
 					),


### PR DESCRIPTION
In TYPO3 CMS 6.2, a new way of registering wizards in TCA was introduced (see https://forge.typo3.org/issues/56268 for more information).
With TYPO3 CMS 7.4, the old way (using 'script' => 'foo.php') was removed. To keep the extension compatible with TYPO3 CMS 7.4, the new way should be used.