### PR TITLE
Add configuration option to enable/disable site-wide parser.

### DIFF
--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2015-11-17T20:29:30Z" product-name="dpn_glossary">
+		<header/>
+		<body>
+			<trans-unit id="extmng.enable.contentProc">
+				<target>Seitenglobals Glossar aktivieren?</target>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" datatype="plaintext" original="messages" date="2015-11-17T20:29:15Z" product-name="dpn_glossary">
+		<header/>
+		<body>
+			<trans-unit id="extmng.enable.contentProc">
+				<source>Enable site-wide glossary?</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=basic/enable/100; type=boolean; label=LLL:EXT:dpn_glossary/Resources/Private/Language/locallang_be.xlf:extmng.enable.contentProc
+contentProc = 1

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -27,7 +27,10 @@ if (!defined('TYPO3_MODE')) {
 	)
 );
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-all'][] = 'Dpn\DpnGlossary\Service\ParserService->pageParser';
+$configuration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$_EXTKEY]);
+if (array_key_exists('contentProc', $configuration) && $configuration['contentProc']) {
+  $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-all'][] = 'Dpn\DpnGlossary\Service\ParserService->pageParser';
+}
 
 if (TRUE === is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl'])) {
 	if (TRUE === is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT'])) {


### PR DESCRIPTION
We have a use-case where the glossary is only used as a list of terms but we do
not need the parser to search other pages for occurances of the terms listed.