### PR TITLE
[BUGFIX] Use save HTML in domTextReplacer

### DIFF
--- a/Classes/Utility/ParserUtility.php
+++ b/Classes/Utility/ParserUtility.php
@@ -157,6 +157,9 @@ class ParserUtility implements SingletonInterface
             $tempDOM = new \DOMDocument();
             // use XHTML tag for avoiding UTF-8 encoding problems
             $tempDOM->loadHTML('<?xml encoding="UTF-8">' . '<div id="replacement">' . $replacement . '</div>');
+            // Reload the save html to parse definitely the DOM
+            $saveHtml = $tempDOM->saveHTML();
+            $tempDOM->loadHTML($saveHtml);
 
             $replacementNode = $DOMText->ownerDocument->createDocumentFragment();
 


### PR DESCRIPTION
On some servers I got errors, because the getElementById returned null. This fixed it by creating save html out of the loaded HTML and then uses the save HTML to create the DOM.