### PR TITLE
Automatic parsing of terms only finds terms that are prefixed with given string

### DIFF
--- a/Classes/Service/ParserService.php
+++ b/Classes/Service/ParserService.php
@@ -362,7 +362,7 @@ class ParserService implements SingletonInterface
          */
         $regex = self::REGEX_DELIMITER .
             '(^|\G|[\s\>[:punct:]]|\<br*\>)' .
-            preg_quote($this->settings['termPrefix']) . '(' . preg_quote($term->getName(), self::REGEX_DELIMITER) . ')' .
+            preg_quote($this->settings['termPrefix'], self::REGEX_DELIMITER) . '(' . preg_quote($term->getName(), self::REGEX_DELIMITER) . ')' .
             '($|[\s\<[:punct:]]|\<br*\>)' .
             '(?![^<]*>|[^<>]*<\/)' .
             self::REGEX_DELIMITER . 'i';

--- a/Classes/Service/ParserService.php
+++ b/Classes/Service/ParserService.php
@@ -362,7 +362,7 @@ class ParserService implements SingletonInterface
          */
         $regex = self::REGEX_DELIMITER .
             '(^|\G|[\s\>[:punct:]]|\<br*\>)' .
-            '(' . preg_quote($term->getName(), self::REGEX_DELIMITER) . ')' .
+            preg_quote($this->settings['termPrefix']) . '(' . preg_quote($term->getName(), self::REGEX_DELIMITER) . ')' .
             '($|[\s\<[:punct:]]|\<br*\>)' .
             '(?![^<]*>|[^<>]*<\/)' .
             self::REGEX_DELIMITER . 'i';

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -44,5 +44,7 @@ plugin.tx_dpnglossary {
     disableParser = 0
     # cat=plugin.tx_dpnglossary//a; type=boolean; label=Parse the terms synonyms (default: enabled)
     parseSynonyms = 1
+    # cat=plugin.tx_dpnglossary//a; type=string; label= Only find terms marked with given prefix
+    termPrefix =
   }
 }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -51,6 +51,8 @@ plugin.tx_dpnglossary {
     disableParser = {$plugin.tx_dpnglossary.settings.disableParser}
     # Parse the terms synonyms
     parseSynonyms = {$plugin.tx_dpnglossary.settings.parseSynonyms}
+    # Only find terms marked with given char
+    termPrefix = {$plugin.tx_dpnglossary.settings.termPrefix}
 
     # Pagination settings
     pagination {


### PR DESCRIPTION
Hello,

i'm currently working on a project, where it is not an option to automatically replace all occurrences of all terms in the glossary, but it is still necessary to automatically replace them. The problem is, that depending on context the term has a different meaning and not all should be replaced.

Example (german): 
ab - is a german word which can occur everywhere in text, but should not be replaces
ab - is a abbreviation in the glossary with a completely different meaning

The customer already delivered the content and prefixed the terms she wanted to replace with an Asterisk. So i just extended dpn_glossary to only replace terms that are prefixed.

* Configurable with {$plugin.tx_dpnglossary.settings.termPrefix}
* Default is the empty string, which won’t change the behaviour of ParserService.php
* If a string is given, the term has to be prefixed by it that the automatic parser exchange wraps it

I hope it can be merged, so we don't have to make a fork of dpn_glossary for the project.

Thanks,
Stephan