### PR TITLE
Performance: Abillity for using CachingFramework

### DIFF
--- a/Classes/Service/ParserService.php
+++ b/Classes/Service/ParserService.php
@@ -119,7 +119,20 @@ class ParserService implements SingletonInterface
             // Assign query settings object to repository
             $termRepository->setDefaultQuerySettings($querySettings);
             //Find all terms
-            $terms = $terms = $termRepository->findByNameLength();
+            if ($this->settings['useCachingFramework']) {
+                $cacheIdentifier = sha1('termsByNameLength');
+                $cache = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Cache\\CacheManager')->getCache('dpnglossary_termscache');
+                $terms = $cache->get($cacheIdentifier);
+                // If $terms is null, it hasn't been cached. Calculate the value and store it in the cache:
+                if ($terms === false) {
+                   $terms = $termRepository->findByNameLength();
+                   // Save value in cache
+                   $cache->set($cacheIdentifier, $terms, ['dpnglossary_termscache']);
+                }
+            } else {
+                $terms = $termRepository->findByNameLength();
+            }
+
             //Sort terms with an individual counter for max replacement per page
             /** @var Term $term */
             foreach ($terms as $term) {

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -54,6 +54,8 @@ plugin.tx_dpnglossary {
     # Use http referer for backlinks
     useHttpReferer = {$plugin.tx_dpnglossary.settings.useHttpReferer}
 
+    useCachingFramework = 1
+
     # Pagination settings
     pagination {
       characters = A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W,X,Y,Z

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -131,3 +131,6 @@ if (
 
     $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['fixedPostVars'] = $realurlConfig;
 }
+if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['dpnglossary_termscache'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['dpnglossary_termscache'] = array();
+}


### PR DESCRIPTION
In website with many entries in the glossar, each initial rendering of a page causes 2 SQL queries for each entry. Using the CF for storing the complete list of terms (and synonyms) reduces the count of queries extremely (but increase the RAM usage).