### PR TITLE
[FEATURE] Call expensive regexParser only if necessary

### DIFF
--- a/Classes/Service/ParserService.php
+++ b/Classes/Service/ParserService.php
@@ -302,7 +302,9 @@ class ParserService implements SingletonInterface
 
             //Check replacement counter
             if (0 !== $term['replacements']) {
-                $this->regexParser($text, $termObject, $replacements, $wrappingCallback);
+                if (stripos($text, $termObject->getName()) !== false) {
+                    $this->regexParser($text, $termObject, $replacements, $wrappingCallback);
+                }
 
                 if (true === (boolean) $this->settings['parseSynonyms']) {
                     /** @var \Featdd\DpnGlossary\Domain\Model\Synonym $synonym */
@@ -312,10 +314,14 @@ class ParserService implements SingletonInterface
                         );
 
                         if (true === (boolean) $this->settings['maxReplacementPerPageRespectSynonyms']) {
-                            $this->regexParser($text, $termObject, $replacements, $wrappingCallback);
+                            if (stripos($text, $termObject->getName()) !== false) {
+                                $this->regexParser($text, $termObject, $replacements, $wrappingCallback);
+                            }
                         } else {
                             $noReplacementCount = -1;
-                            $this->regexParser($text, $termObject, $noReplacementCount, $wrappingCallback);
+                            if (stripos($text, $termObject->getName()) !== false) {
+                                $this->regexParser($text, $termObject, $noReplacementCount, $wrappingCallback);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
regexParser() is a bit complex. But for many texts and terms, there's no match for a glossary entry, and we do not need to fire this performance expensive method. 
Simply adding a test if the term is in the text *before* doing the heavy stuff, saves much CPU time.

(In my use-case this lowers the count of method calls by 95T and lowers the CPU time by 50%)