### PR TITLE
[FEATURE] Move realurl configuration to hook (fixes #104)

### DIFF
--- a/Classes/Hook/RealurlHook.php
+++ b/Classes/Hook/RealurlHook.php
@@ -1,0 +1,94 @@
+<?php
+namespace Featdd\DpnGlossary\Hook;
+
+/***************************************************************
+ *  Copyright notice
+ *
+ *  (c) 2017 Julian Hofmann <julian.hofmann@webenergy.de>
+ *
+ *  All rights reserved
+ *
+ *  This script is part of the TYPO3 project. The TYPO3 project is
+ *  free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  The GNU General Public License can be found at
+ *  http://www.gnu.org/copyleft/gpl.html.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+/**
+ * @license http://www.gnu.org/licenses/gpl.html GNU General Public License, version 3 or later
+ */
+class RealurlHook
+{
+    /**
+     * Generates additional RealURL configuration and merges it with provided configuration
+     *
+     * @param array $params Default configuration
+     * @param \DmitryDulepov\Realurl\Configuration\AutomaticConfigurator $pObj Parent object
+     * @return array configuration
+     */
+    public function addConfig($params, &$pObj)
+    {
+        return array_merge_recursive($params['config'], [
+            'fixedPostVars' => [
+                'dpn_glossary_list_RealUrlConfig' => [
+                    [
+                        'GETvar' => 'tx_dpnglossary_glossarylist[controller]',
+                        'noMatch' => 'bypass',
+                    ],
+                    [
+                        'GETvar' => 'tx_dpnglossary_glossarylist[action]',
+                        'noMatch' => 'bypass',
+                    ],
+                    [
+                        'GETvar' => 'tx_dpnglossary_glossarylist[@widget_0][character]',
+                    ],
+                ],
+                'dpn_glossary_detail_RealUrlConfig' => [
+                    [
+                        'GETvar' => 'tx_dpnglossary_glossarydetail[controller]',
+                        'noMatch' => 'bypass',
+                    ],
+                    [
+                        'GETvar' => 'tx_dpnglossary_glossarydetail[action]',
+                        'noMatch' => 'bypass',
+                    ],
+                    [
+                        'GETvar' => 'tx_dpnglossary_glossarydetail[term]',
+                        'lookUpTable' => [
+                            'table' => 'tx_dpnglossary_domain_model_term',
+                            'id_field' => 'uid',
+                            'alias_field' => 'name',
+                            'addWhereClause' => ' AND NOT deleted',
+                            'useUniqueCache' => 1,
+                            'useUniqueCache_conf' => [
+                                'strtolower' => 1,
+                                'spaceCharacter' => '-',
+                            ],
+                            'languageGetVar' => 'L',
+                            'languageExceptionUids' => '',
+                            'languageField' => 'sys_language_uid',
+                            'transOrigPointerField' => 'l10n_parent',
+                            'autoUpdate' => 1,
+                            'expireDays' => 180,
+                        ],
+                    ],
+                    [
+                        'GETvar' => 'tx_dpnglossary_glossarydetail[pageUid]',
+                        'optional' => true,
+                    ],
+                ]
+            ]
+        ]);
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -68,66 +68,7 @@ if (true === version_compare(\TYPO3\CMS\Core\Utility\VersionNumberUtility::getNu
         ['name' => 'search']
     );
 }
-
-if (
-    true === is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']) &&
-    true === is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT'])
-) {
-    if (false === is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['fixedPostVars'])) {
-        $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['fixedPostVars'] = array();
-    }
-
-    $realurlConfig = array(
-        $_EXTKEY . '_list_RealUrlConfig' => array(
-            array(
-                'GETvar' => 'tx_dpnglossary_glossarylist[controller]',
-                'noMatch' => 'bypass',
-            ),
-            array(
-                'GETvar' => 'tx_dpnglossary_glossarylist[action]',
-                'noMatch' => 'bypass',
-            ),
-            array(
-                'GETvar' => 'tx_dpnglossary_glossarylist[@widget_0][character]',
-            ),
-        ),
-        $_EXTKEY . '_detail_RealUrlConfig' => array(
-            array(
-                'GETvar' => 'tx_dpnglossary_glossarydetail[controller]',
-                'noMatch' => 'bypass',
-            ),
-            array(
-                'GETvar' => 'tx_dpnglossary_glossarydetail[action]',
-                'noMatch' => 'bypass',
-            ),
-            array(
-                'GETvar' => 'tx_dpnglossary_glossarydetail[term]',
-                'lookUpTable' => array(
-                    'table' => 'tx_dpnglossary_domain_model_term',
-                    'id_field' => 'uid',
-                    'alias_field' => 'name',
-                    'addWhereClause' => ' AND NOT deleted',
-                    'useUniqueCache' => 1,
-                    'useUniqueCache_conf' => array(
-                        'strtolower' => 1,
-                        'spaceCharacter' => '-',
-                    ),
-                    'languageGetVar' => 'L',
-                    'languageExceptionUids' => '',
-                    'languageField' => 'sys_language_uid',
-                    'transOrigPointerField' => 'l10n_parent',
-                    'autoUpdate' => 1,
-                    'expireDays' => 180,
-                ),
-            ),
-            array(
-                'GETvar' => 'tx_dpnglossary_glossarydetail[pageUid]',
-                'optional' => true,
-            ),
-        ),
-    );
-
-    $realurlConfig += $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['fixedPostVars'];
-
-    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['fixedPostVars'] = $realurlConfig;
+if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('realurl')) {
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/realurl/class.tx_realurl_autoconfgen.php']['extensionConfiguration']['dpn_glossary'] =
+        \Featdd\DpnGlossary\Hook\RealurlHook::class . '->addConfig';
 }


### PR DESCRIPTION
In my opinion, injecting realurl configuration via ext_localconf.php is in general the wrong way.

For automatic configuration, there's a hook in realurl, which is applied if "Auto configuration" is activated (https://docs.typo3.org/typo3cms/extensions/realurl/1.13.3/Realurl/AutomaticConfiguration/AutomaticConfigurationOfExtensions/Index.html - still the same in v2.x).
If it is deactivated, it should be the integrators job to write the realurl configuration. For this case, the suggested configuration should be part of the documentation, but not injected without approval of the integrator.