### PR TITLE
use language for cache

### DIFF
--- a/Classes/Service/ParserService.php
+++ b/Classes/Service/ParserService.php
@@ -127,7 +127,7 @@ class ParserService implements SingletonInterface
             if (false === (bool) $this->settings['useCachingFramework']) {
                 $terms = $termRepository->findByNameLength();
             } else {
-                $cacheIdentifier = sha1('termsByNameLength');
+                $cacheIdentifier = sha1('termsByNameLength' . $querySettings->getLanguageUid());
                 $cache = $cacheManager->getCache('dpnglossary_termscache');
                 $terms = $cache->get($cacheIdentifier);
 


### PR DESCRIPTION
The terms selection doesn't respect the language, if you activate the caching framework. Therefore you should add the language value into the cache identifier.