### PR TITLE
use HTML5DOMDocument instead DOMDocument

### DIFF
--- a/Classes/Service/ParserService.php
+++ b/Classes/Service/ParserService.php
@@ -23,6 +23,7 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use IvoPetkov\HTML5DOMDocument;
 
 /**
  * @package DpnGlossary
@@ -198,7 +199,7 @@ class ParserService implements SingletonInterface
         }
 
         //Create new DOMDocument
-        $DOM = new \DOMDocument();
+        $DOM = new HTML5DOMDocument();
 
         // Prevent crashes caused by HTML5 entities with internal errors
         libxml_use_internal_errors(true);

--- a/Classes/Utility/ParserUtility.php
+++ b/Classes/Utility/ParserUtility.php
@@ -13,6 +13,7 @@ namespace Featdd\DpnGlossary\Utility;
  ***/
 
 use TYPO3\CMS\Core\SingletonInterface;
+use IvoPetkov\HTML5DOMDocument;
 
 /**
  * @package DpnGlossary
@@ -136,7 +137,7 @@ class ParserUtility implements SingletonInterface
     public static function domTextReplacer(\DOMText $DOMText, $replacement): void
     {
         if (false === empty(trim($replacement))) {
-            $tempDOM = new \DOMDocument();
+            $tempDOM = new HTML5DOMDocument();
             // use XHTML tag for avoiding UTF-8 encoding problems
             $tempDOM->loadHTML('<?xml encoding="UTF-8">' . '<!DOCTYPE html><html><body><div id="replacement">' . $replacement . '</div></body></html>');
 

--- a/Classes/ViewHelpers/Widget/Controller/PaginateController.php
+++ b/Classes/ViewHelpers/Widget/Controller/PaginateController.php
@@ -124,7 +124,7 @@ class PaginateController extends AbstractWidgetController
                 $getter = 'get' . GeneralUtility::underscoredToUpperCamelCase($this->field);
 
                 if (true === method_exists($firstObject[0], $getter)) {
-                    $this->currentCharacter = strtoupper($firstObject[0]->{$getter}()[0]);
+                    $this->currentCharacter = 'A-Z';
                 } else {
                     throw new Exception('Getter for "' . $this->field . '" in "' . \get_class($firstObject[0]) . '" does not exist',
                         1433257601);

--- a/Configuration/TCA/tx_dpnglossary_domain_model_term.php
+++ b/Configuration/TCA/tx_dpnglossary_domain_model_term.php
@@ -12,6 +12,7 @@ return [
         'languageField' => 'sys_language_uid',
         'transOrigPointerField' => 'l10n_parent',
         'transOrigDiffSourceField' => 'l10n_diffsource',
+        'translationSource' => 'l10n_source',
         'delete' => 'deleted',
         'enablecolumns' => [
             'disabled' => 'hidden',

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     "typo3/cms-core": "~9.5.0",
     "php": "^7.2",
     "ext-dom": "*",
-    "ext-libxml": "*"
+    "ext-libxml": "*",
+    "require ivopetkov/html5-dom-document-php": "^2"
   },
   "autoload": {
     "psr-4": {

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -36,6 +36,7 @@ CREATE TABLE tx_dpnglossary_domain_model_term (
 
   t3_origuid           int(11) DEFAULT '0'             NOT NULL,
   sys_language_uid     int(11) DEFAULT '0'             NOT NULL,
+  l10n_source          int(11) DEFAULT '0'             NOT NULL,
   l10n_parent          int(11) DEFAULT '0'             NOT NULL,
   l10n_diffsource      mediumblob,
 


### PR DESCRIPTION
Description of the problem :
Before processing by **DOMDocument** :
```
<picture>
    <source srcset="img.webp 100vw" type="image/webp">
    <img src="img.jpg" alt="">
</picture>
```
After processing by **DOMDocument** : 
```
<picture>
    <source srcset="img.webp 100vw" type="image/webp">
          <img src="img.jpg" alt="">
    </source>
</picture>
```
` <source>` should not have a closing tag, this can cause problems for html validation.
Class **HTML5DOMDocument** no have this problem.

And other small fixes :
1. Added l10n_source to tx_dpnglossary_domain_model_term table;
2. Show all terms if no characters is defined;