### PR TITLE
Feature: add pageTitleProvider for terms

### DIFF
--- a/Classes/Controller/TermController.php
+++ b/Classes/Controller/TermController.php
@@ -16,6 +16,7 @@ namespace Featdd\DpnGlossary\Controller;
 
 use Featdd\DpnGlossary\Domain\Model\Term;
 use Featdd\DpnGlossary\Domain\Repository\TermRepository;
+use Featdd\DpnGlossary\PageTitle\TermPageTitleProvider;
 use Featdd\DpnGlossary\ViewHelpers\Widget\Controller\PaginateController;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -106,5 +107,9 @@ class TermController extends ActionController
         }
 
         $this->view->assign('term', $term);
+
+        /** @var TermPageTitleProvider $pageTitleProvider */
+        $pageTitleProvider = GeneralUtility::makeInstance(TermPageTitleProvider::class);
+        $pageTitleProvider->setTitle($term->getName());
     }
 }

--- a/Classes/PageTitle/TermPageTitleProvider.php
+++ b/Classes/PageTitle/TermPageTitleProvider.php
@@ -1,0 +1,15 @@
+<?php
+namespace Featdd\DpnGlossary\PageTitle;
+
+use TYPO3\CMS\Core\PageTitle\AbstractPageTitleProvider;
+
+class TermPageTitleProvider extends AbstractPageTitleProvider
+{
+    /**
+     * @param string $title
+     */
+    public function setTitle(string $title)
+    {
+        $this->title = $title;
+    }
+}

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -150,3 +150,10 @@ plugin.tx_dpnglossary {
 [globalVar = LIT:1 = {$plugin.tx_dpnglossary.settings.addStylesheet}]
   page.includeCSS.dpnglossary = EXT:dpn_glossary/Resources/Public/css/styles.css
 [global]
+
+config.pageTitleProviders {
+  glossaryTerm {
+    provider = Featdd\DpnGlossary\PageTitle\TermPageTitleProvider
+    before = altPageTitle
+  }
+}


### PR DESCRIPTION
Hi,

I propose to use the PageTitle API instead of a Typoscript workaround to display page titles for terms.

Regards,
Gregor