### PR TITLE
[BUGFIX] Changed check for forbidden parent elements

### DIFF
--- a/Classes/Service/ParserService.php
+++ b/Classes/Service/ParserService.php
@@ -274,7 +274,7 @@ class ParserService implements SingletonInterface
                 );
 
                 // check if element is children of a forbidden parent
-                if (false === \in_array($parentTags, $forbiddenParentTags, true)) {
+                if (false === (bool)count(array_intersect($parentTags, $forbiddenParentTags))) {
                     /** @var \DOMNode $childNode */
                     for ($i = 0; $i < $DOMTag->childNodes->length; $i++) {
                         $childNode = $DOMTag->childNodes->item($i);


### PR DESCRIPTION
Accidentally did nearly the same change as the Issue Opener.

the `in_array($array1, $array2)` will never return true, because both Arrays only have a single dimension