### PR TITLE
[FEATURE] Limit parsing of DOM to configurable node/tag (ID)

### DIFF
--- a/Classes/Service/ParserService.php
+++ b/Classes/Service/ParserService.php
@@ -229,7 +229,7 @@ class ParserService implements SingletonInterface
         $isPriorisedSynonymParsing = (boolean) ($this->settings['priorisedSynonymParsing'] ?? true);
 
         // Limit parsing to a single node with this ID
-        $limitParingId = (string)($this->settings['limitParsingId'] ?? '');
+        $limitParsingId = (string)($this->settings['limitParsingId'] ?? '');
 
         // Add "a" if unknowingly deleted to prevent errors
         if (false === \in_array(self::$alwaysIgnoreParentTags, $forbiddenParentTags, true)) {
@@ -244,7 +244,7 @@ class ParserService implements SingletonInterface
         // Prevent crashes caused by HTML5 entities with internal errors
         libxml_use_internal_errors(true);
 
-        $limitToXpath = !empty($limitParingId);
+        $limitToXpath = !empty($limitParsingId);
         if ($limitToXpath === true) {
             //Create new DOMDocument
             $DOMpage = new DOMDocument();
@@ -268,7 +268,7 @@ class ParserService implements SingletonInterface
             /** @var \DOMNode $DOMcontent */
             $DOMcontent = $DOMXPathPage
                 ->query(
-                    '//*[@id="' . $limitParingId . '"]',
+                    '//*[@id="' . $limitParsingId . '"]',
                     $DOMpage->getElementsByTagName('body')->item(0)
                 )
                 ->item(0);
@@ -287,7 +287,7 @@ class ParserService implements SingletonInterface
                 throw new Exception('Parsers DOM Document could\'nt load the html');
             }
             /** @var \DOMNode $DOMBody */
-            $DOMBody = $DOM->getElementById($limitParingId);
+            $DOMBody = $DOM->getElementById($limitParsingId);
         } else {
             // Load Page HTML in DOM and check if HTML is valid else abort
             // use XHTML tag for avoiding UTF-8 encoding problems
@@ -427,12 +427,12 @@ class ParserService implements SingletonInterface
         }
 
         if ($limitToXpath === true) {
-            $content = $DOM->getElementById($limitParingId);
+            $content = $DOM->getElementById($limitParsingId);
             $content = $DOMpage->importNode($content, true);
             $DOMpage
-                ->getElementById($limitParingId)
+                ->getElementById($limitParsingId)
                 ->parentNode
-                ->replaceChild($content, $DOMpage->getElementById($limitParingId));
+                ->replaceChild($content, $DOMpage->getElementById($limitParsingId));
             $html = $DOMpage->saveHTML();
         } else {
             $html = $DOM->saveHTML();

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -47,6 +47,8 @@ plugin.tx_dpnglossary {
     parseSynonyms = 1
     # cat=dpn_glossary/settings/a; type=boolean; label=Priorise the synonyms before the actual term when parsing (default: enabled)
     priorisedSynonymParsing = 1
+    # cat=dpn_glossary/settings/a; type=string; label=Limit parsing to a single node with this ID
+    limitParingId =
     # cat=dpn_glossary/settings/a; type=boolean; label=Use the origin term for content object data when parsing synonyms (default: disabled)
     useTermForSynonymParsingDataWrap = 0
     # cat=dpn_glossary/settings/a; type=boolean; label=Add the extension stylesheet (default: enabled)

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -48,7 +48,7 @@ plugin.tx_dpnglossary {
     # cat=dpn_glossary/settings/a; type=boolean; label=Priorise the synonyms before the actual term when parsing (default: enabled)
     priorisedSynonymParsing = 1
     # cat=dpn_glossary/settings/a; type=string; label=Limit parsing to a single node with this ID
-    limitParingId =
+    limitParsingId =
     # cat=dpn_glossary/settings/a; type=boolean; label=Use the origin term for content object data when parsing synonyms (default: disabled)
     useTermForSynonymParsingDataWrap = 0
     # cat=dpn_glossary/settings/a; type=boolean; label=Add the extension stylesheet (default: enabled)

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -53,6 +53,8 @@ plugin.tx_dpnglossary {
     parseSynonyms = {$plugin.tx_dpnglossary.settings.parseSynonyms}
     # Priorise the synonyms for parsing
     priorisedSynonymParsing = {$plugin.tx_dpnglossary.settings.priorisedSynonymParsing}
+    # Limit parsing to a single node with this ID
+    limitParingId = {$plugin.tx_dpnglossary.settings.limitParingId}
     # Use the origin term for content object data when parsing synonyms
     useTermForSynonymParsingDataWrap = {$plugin.tx_dpnglossary.settings.useTermForSynonymParsingDataWrap}
 

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -54,7 +54,7 @@ plugin.tx_dpnglossary {
     # Priorise the synonyms for parsing
     priorisedSynonymParsing = {$plugin.tx_dpnglossary.settings.priorisedSynonymParsing}
     # Limit parsing to a single node with this ID
-    limitParingId = {$plugin.tx_dpnglossary.settings.limitParingId}
+    limitParsingId = {$plugin.tx_dpnglossary.settings.limitParsingId}
     # Use the origin term for content object data when parsing synonyms
     useTermForSynonymParsingDataWrap = {$plugin.tx_dpnglossary.settings.useTermForSynonymParsingDataWrap}
 

--- a/Documentation/Configuration/ExtensionSettings/Index.rst
+++ b/Documentation/Configuration/ExtensionSettings/Index.rst
@@ -104,7 +104,7 @@ plugin.tx_dpnglossary.settings:
 .. container:: table-row
 
   Constant
-    settings.limitParingId
+    settings.limitParsingId
 
   Data Type
     string

--- a/Documentation/Configuration/ExtensionSettings/Index.rst
+++ b/Documentation/Configuration/ExtensionSettings/Index.rst
@@ -104,6 +104,17 @@ plugin.tx_dpnglossary.settings:
 .. container:: table-row
 
   Constant
+    settings.limitParingId
+
+  Data Type
+    string
+
+  Description
+    Limits parsing for terms to the *one* node/tag having this ID (e.g. 'content' for a `<div id="content">`)
+
+.. container:: table-row
+
+  Constant
     settings.parsingTags
 
   Data Type


### PR DESCRIPTION
Introduces new setting `limitParsingId` which can be used to limit the parsing to a certain node/tag with this id.

If set, the parser loads the full page in a DOMdocument, extracts the configured node/tag as a separate DOMdocument, pareses only *this* much smaller DOMdocument, and replaces the node/tag in the DOMdocument of the whole page.

This way only the relevant part of a page must be parsed. Mostly, you have already some kind of wrapper around your content and only this content is relevant to the glossary. Navigations (in particular megamenus), sidebars, etc. don't need to be checked for matching XPaths or terms anymore.

Fixes: #185 