### PR TITLE
[FEATURE] Use a simplified SimpleTerm-object for parser && lazy-loadi…

### DIFF
--- a/Classes/Domain/Model/AbstractTerm.php
+++ b/Classes/Domain/Model/AbstractTerm.php
@@ -1,0 +1,283 @@
+<?php
+declare(strict_types=1);
+
+namespace Featdd\DpnGlossary\Domain\Model;
+
+/***
+ *
+ * This file is part of the "dreipunktnull Glossar" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ *  (c) 2022 Daniel Dorndorf <dorndorf@featdd.de>
+ *
+ ***/
+
+use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+use TYPO3\CMS\Extbase\Domain\Model\FileReference;
+
+/**
+ * @package Featdd\DpnGlossary\Domain\Model
+ */
+abstract class AbstractTerm extends AbstractEntity implements TermInterface
+{
+    public const TABLE = 'tx_dpnglossary_domain_model_term';
+
+    /**
+     * @var string
+     */
+    protected $name = '';
+
+    /**
+     * @var string
+     */
+    protected $parsingName = '';
+
+    /**
+     * @var string
+     */
+    protected $tooltiptext = '';
+
+    /**
+     * @var string
+     */
+    protected $termType = '';
+
+    /**
+     * @var string
+     */
+    protected $termLang = '';
+
+    /**
+     * @var string
+     */
+    protected $termMode = '';
+
+
+    /**
+     * @var bool
+     */
+    protected $excludeFromParsing = false;
+
+    /**
+     * @var bool
+     */
+    protected $caseSensitive = false;
+
+    /**
+     * @var int
+     */
+    protected $maxReplacements = -1;
+
+    /**
+     * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Featdd\DpnGlossary\Domain\Model\Synonym>
+     */
+    protected $synonyms;
+
+    public function __construct()
+    {
+        $this->synonyms = new ObjectStorage();
+    }
+
+    /**
+     * @return string $name
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName(string $name): void
+    {
+        $this->parsingName = $name;
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getParsingName(): string
+    {
+        if (true === empty($this->parsingName)) {
+            return $this->name;
+        }
+
+        return $this->parsingName;
+    }
+
+    /**
+     * @param string $parsingName
+     */
+    public function setParsingName(string $parsingName): void
+    {
+        $this->parsingName = $parsingName;
+    }
+
+    /**
+     * @return string $tooltiptext
+     */
+    public function getTooltiptext(): string
+    {
+        return $this->tooltiptext;
+    }
+
+    /**
+     * @param string $tooltiptext
+     */
+    public function setTooltiptext(string $tooltiptext): void
+    {
+        $this->tooltiptext = $tooltiptext;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTermType(): string
+    {
+        return $this->termType;
+    }
+
+    /**
+     * @param string $termType
+     */
+    public function setTermType(string $termType): void
+    {
+        $this->termType = $termType;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTermLang(): string
+    {
+        return $this->termLang;
+    }
+
+    /**
+     * @param string $termLang
+     */
+    public function setTermLang(string $termLang): void
+    {
+        $this->termLang = $termLang;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTermMode(): string
+    {
+        return $this->termMode;
+    }
+
+    /**
+     * @param string $termMode
+     */
+    public function setTermMode(string $termMode): void
+    {
+        $this->termMode = $termMode;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getExcludeFromParsing(): bool
+    {
+        return $this->excludeFromParsing;
+    }
+
+    /**
+     * @param bool $excludeFromParsing
+     */
+    public function setExcludeFromParsing(bool $excludeFromParsing): void
+    {
+        $this->excludeFromParsing = $excludeFromParsing;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCaseSensitive(): bool
+    {
+        return $this->caseSensitive;
+    }
+
+    /**
+     * @param bool $caseSensitive
+     */
+    public function setCaseSensitive(bool $caseSensitive): void
+    {
+        $this->caseSensitive = $caseSensitive;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxReplacements(): int
+    {
+        return $this->maxReplacements;
+    }
+
+    /**
+     * @param int $maxReplacements
+     */
+    public function setMaxReplacements(int $maxReplacements): void
+    {
+        $this->maxReplacements = $maxReplacements;
+    }
+
+    /**
+     * @return \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Featdd\DpnGlossary\Domain\Model\Synonym>
+     */
+    public function getSynonyms(): ObjectStorage
+    {
+        return $this->synonyms;
+    }
+
+    /**
+     * @param \Featdd\DpnGlossary\Domain\Model\Synonym $synonym
+     */
+    public function addSynonym(Synonym $synonym): void
+    {
+        $this->synonyms->attach($synonym);
+    }
+
+    /**
+     * @param \Featdd\DpnGlossary\Domain\Model\Synonym $synonym
+     */
+    public function removeSynonym(Synonym $synonym): void
+    {
+        $this->synonyms->detach($synonym);
+    }
+
+    /**
+     * @param \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Featdd\DpnGlossary\Domain\Model\Synonym> $synonyms
+     */
+    public function setSynonyms(ObjectStorage $synonyms): void
+    {
+        $this->synonyms = $synonyms;
+    }
+
+    /**
+     * @return array
+     */
+    public function __toArray(): array
+    {
+        return [
+            'uid' => $this->getUid(),
+            'pid' => $this->getPid(),
+            'name' => $this->getName(),
+            'parsing_name' => $this->getParsingName(),
+            'tooltiptext' => $this->getTooltiptext(),
+            'term_type' => $this->getTermType(),
+            'term_lang' => $this->getTermLang(),
+            'term_mode' => $this->getTermMode(),
+            'exclude_from_parsing' => $this->getExcludeFromParsing(),
+            'synonyms' => $this->getSynonyms(),
+        ];
+    }
+}

--- a/Classes/Domain/Model/SimpleTerm.php
+++ b/Classes/Domain/Model/SimpleTerm.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Featdd\DpnGlossary\Domain\Model;
+
+/***
+ *
+ * This file is part of the "dreipunktnull Glossar" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ *  (c) 2022 Daniel Dorndorf <dorndorf@featdd.de>
+ *
+ ***/
+
+/**
+ * @package Featdd\DpnGlossary\Domain\Model
+ */
+class SimpleTerm extends AbstractTerm
+{}

--- a/Classes/Domain/Model/Term.php
+++ b/Classes/Domain/Model/Term.php
@@ -14,6 +14,7 @@ namespace Featdd\DpnGlossary\Domain\Model;
  *
  ***/
 
+use TYPO3\CMS\Extbase\Annotation as Extbase;
 use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
@@ -21,40 +22,8 @@ use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 /**
  * @package Featdd\DpnGlossary\Domain\Model
  */
-class Term extends AbstractEntity
+class Term extends AbstractTerm
 {
-    public const TABLE = 'tx_dpnglossary_domain_model_term';
-
-    /**
-     * @var string
-     */
-    protected $name = '';
-
-    /**
-     * @var string
-     */
-    protected $parsingName = '';
-
-    /**
-     * @var string
-     */
-    protected $tooltiptext = '';
-
-    /**
-     * @var string
-     */
-    protected $termType = '';
-
-    /**
-     * @var string
-     */
-    protected $termLang = '';
-
-    /**
-     * @var string
-     */
-    protected $termMode = '';
-
     /**
      * @var string
      */
@@ -71,141 +40,22 @@ class Term extends AbstractEntity
     protected $metaDescription = '';
 
     /**
-     * @var bool
-     */
-    protected $excludeFromParsing = false;
-
-    /**
-     * @var bool
-     */
-    protected $caseSensitive = false;
-
-    /**
-     * @var int
-     */
-    protected $maxReplacements = -1;
-
-    /**
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Featdd\DpnGlossary\Domain\Model\Description>
+     * @Extbase\ORM\Lazy
      */
     protected $descriptions;
 
     /**
-     * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Featdd\DpnGlossary\Domain\Model\Synonym>
-     */
-    protected $synonyms;
-
-    /**
      * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\TYPO3\CMS\Extbase\Domain\Model\FileReference>
+     * @Extbase\ORM\Lazy
      */
     protected $media;
 
     public function __construct()
     {
+        parent::__construct();
         $this->descriptions = new ObjectStorage();
-        $this->synonyms = new ObjectStorage();
         $this->media = new ObjectStorage();
-    }
-
-    /**
-     * @return string $name
-     */
-    public function getName(): string
-    {
-        return $this->name;
-    }
-
-    /**
-     * @param string $name
-     */
-    public function setName(string $name): void
-    {
-        $this->parsingName = $name;
-        $this->name = $name;
-    }
-
-    /**
-     * @return string
-     */
-    public function getParsingName(): string
-    {
-        if (true === empty($this->parsingName)) {
-            return $this->name;
-        }
-
-        return $this->parsingName;
-    }
-
-    /**
-     * @param string $parsingName
-     */
-    public function setParsingName(string $parsingName): void
-    {
-        $this->parsingName = $parsingName;
-    }
-
-    /**
-     * @return string $tooltiptext
-     */
-    public function getTooltiptext(): string
-    {
-        return $this->tooltiptext;
-    }
-
-    /**
-     * @param string $tooltiptext
-     */
-    public function setTooltiptext(string $tooltiptext): void
-    {
-        $this->tooltiptext = $tooltiptext;
-    }
-
-    /**
-     * @return string
-     */
-    public function getTermType(): string
-    {
-        return $this->termType;
-    }
-
-    /**
-     * @param string $termType
-     */
-    public function setTermType(string $termType): void
-    {
-        $this->termType = $termType;
-    }
-
-    /**
-     * @return string
-     */
-    public function getTermLang(): string
-    {
-        return $this->termLang;
-    }
-
-    /**
-     * @param string $termLang
-     */
-    public function setTermLang(string $termLang): void
-    {
-        $this->termLang = $termLang;
-    }
-
-    /**
-     * @return string
-     */
-    public function getTermMode(): string
-    {
-        return $this->termMode;
-    }
-
-    /**
-     * @param string $termMode
-     */
-    public function setTermMode(string $termMode): void
-    {
-        $this->termMode = $termMode;
     }
 
     /**
@@ -259,54 +109,6 @@ class Term extends AbstractEntity
     }
 
     /**
-     * @return bool
-     */
-    public function getExcludeFromParsing(): bool
-    {
-        return $this->excludeFromParsing;
-    }
-
-    /**
-     * @param bool $excludeFromParsing
-     */
-    public function setExcludeFromParsing(bool $excludeFromParsing): void
-    {
-        $this->excludeFromParsing = $excludeFromParsing;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isCaseSensitive(): bool
-    {
-        return $this->caseSensitive;
-    }
-
-    /**
-     * @param bool $caseSensitive
-     */
-    public function setCaseSensitive(bool $caseSensitive): void
-    {
-        $this->caseSensitive = $caseSensitive;
-    }
-
-    /**
-     * @return int
-     */
-    public function getMaxReplacements(): int
-    {
-        return $this->maxReplacements;
-    }
-
-    /**
-     * @param int $maxReplacements
-     */
-    public function setMaxReplacements(int $maxReplacements): void
-    {
-        $this->maxReplacements = $maxReplacements;
-    }
-
-    /**
      * @return \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Featdd\DpnGlossary\Domain\Model\Description>
      */
     public function getDescriptions(): ObjectStorage
@@ -336,38 +138,6 @@ class Term extends AbstractEntity
     public function setDescriptions(ObjectStorage $descriptions): void
     {
         $this->descriptions = $descriptions;
-    }
-
-    /**
-     * @return \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Featdd\DpnGlossary\Domain\Model\Synonym>
-     */
-    public function getSynonyms(): ObjectStorage
-    {
-        return $this->synonyms;
-    }
-
-    /**
-     * @param \Featdd\DpnGlossary\Domain\Model\Synonym $synonym
-     */
-    public function addSynonym(Synonym $synonym): void
-    {
-        $this->synonyms->attach($synonym);
-    }
-
-    /**
-     * @param \Featdd\DpnGlossary\Domain\Model\Synonym $synonym
-     */
-    public function removeSynonym(Synonym $synonym): void
-    {
-        $this->synonyms->detach($synonym);
-    }
-
-    /**
-     * @param \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Featdd\DpnGlossary\Domain\Model\Synonym> $synonyms
-     */
-    public function setSynonyms(ObjectStorage $synonyms): void
-    {
-        $this->synonyms = $synonyms;
     }
 
     /**

--- a/Classes/Domain/Model/TermInterface.php
+++ b/Classes/Domain/Model/TermInterface.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Featdd\DpnGlossary\Domain\Model;
+
+/***
+ *
+ * This file is part of the "dreipunktnull Glossar" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ *  (c) 2022 Daniel Dorndorf <dorndorf@featdd.de>
+ *
+ ***/
+
+interface TermInterface {
+    /**
+     * @return string
+     */
+    public function getName(): string;
+}

--- a/Classes/Domain/Repository/AbstractTermRepository.php
+++ b/Classes/Domain/Repository/AbstractTermRepository.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace Featdd\DpnGlossary\Domain\Repository;
+
+/***
+ *
+ * This file is part of the "dreipunktnull Glossar" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ *  (c) 2022 Daniel Dorndorf <dorndorf@featdd.de>
+ *
+ ***/
+
+use Featdd\DpnGlossary\Domain\Model\Term;
+use Featdd\DpnGlossary\Domain\Model\TermInterface;
+use TYPO3\CMS\Extbase\Persistence\Exception\InvalidQueryException;
+use TYPO3\CMS\Extbase\Persistence\QueryInterface;
+use TYPO3\CMS\Extbase\Persistence\Repository;
+
+/**
+ * @package Featdd\DpnGlossary\Domain\Repository
+ */
+abstract class AbstractTermRepository extends Repository
+{
+    public const DEFAULT_LIMIT = 5;
+
+    /**
+     * @var array
+     */
+    protected $defaultOrderings = [
+        'name' => QueryInterface::ORDER_ASCENDING,
+    ];
+
+    /**
+     * find all terms sorted by name length
+     *
+     * @return array
+     */
+    public function findByNameLength(): array
+    {
+        $terms = $this->findAll()->toArray();
+
+        /**
+         * Sorting Callback
+         *
+         * @param Term $termA
+         * @param Term $termB
+         * @return int
+         */
+        $sortingCallback = function (TermInterface $termA, TermInterface $termB) {
+            return mb_strlen($termB->getName()) - mb_strlen($termA->getName());
+        };
+
+        // Sort terms
+        usort($terms, $sortingCallback);
+
+        return $terms;
+    }
+
+    /**
+     * finds terms by multiple uids
+     *
+     * @param int[] $uids
+     * @return array
+     */
+    public function findByUids(array $uids): array
+    {
+        $query = $this->createQuery();
+
+        if (0 === count($uids)) {
+            return [];
+        }
+
+        try {
+            $query->matching(
+                $query->in('uid', $uids)
+            );
+        } catch (InvalidQueryException $e) {
+            // nothing
+        }
+
+        return $query->execute()->toArray();
+    }
+}

--- a/Classes/Domain/Repository/SimpleTermRepository.php
+++ b/Classes/Domain/Repository/SimpleTermRepository.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Featdd\DpnGlossary\Domain\Repository;
+
+/***
+ *
+ * This file is part of the "dreipunktnull Glossar" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ *  (c) 2022 Daniel Dorndorf <dorndorf@featdd.de>
+ *
+ ***/
+
+/**
+ * @package Featdd\DpnGlossary\Domain\Repository
+ */
+class SimpleTermRepository extends AbstractTermRepository
+{}

--- a/Classes/Domain/Repository/TermRepository.php
+++ b/Classes/Domain/Repository/TermRepository.php
@@ -15,76 +15,14 @@ namespace Featdd\DpnGlossary\Domain\Repository;
  ***/
 
 use Featdd\DpnGlossary\Domain\Model\Term;
-use TYPO3\CMS\Extbase\Persistence\Exception\InvalidQueryException;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
-use TYPO3\CMS\Extbase\Persistence\Repository;
 
 /**
  * @package Featdd\DpnGlossary\Domain\Repository
  */
-class TermRepository extends Repository
+class TermRepository extends AbstractTermRepository
 {
-    public const DEFAULT_LIMIT = 5;
-
-    /**
-     * @var array
-     */
-    protected $defaultOrderings = [
-        'name' => QueryInterface::ORDER_ASCENDING,
-    ];
-
-    /**
-     * find all terms sorted by name length
-     *
-     * @return array
-     */
-    public function findByNameLength(): array
-    {
-        $terms = $this->findAll()->toArray();
-
-        /**
-         * Sorting Callback
-         *
-         * @param Term $termA
-         * @param Term $termB
-         * @return int
-         */
-        $sortingCallback = function (Term $termA, Term $termB) {
-            return mb_strlen($termB->getName()) - mb_strlen($termA->getName());
-        };
-
-        // Sort terms
-        usort($terms, $sortingCallback);
-
-        return $terms;
-    }
-
-    /**
-     * finds terms by multiple uids
-     *
-     * @param int[] $uids
-     * @return array
-     */
-    public function findByUids(array $uids): array
-    {
-        $query = $this->createQuery();
-
-        if (0 === count($uids)) {
-            return [];
-        }
-
-        try {
-            $query->matching(
-                $query->in('uid', $uids)
-            );
-        } catch (InvalidQueryException $e) {
-            // nothing
-        }
-
-        return $query->execute()->toArray();
-    }
-
     /**
      * finds the newest terms
      *

--- a/Configuration/Extbase/Persistence/Classes.php
+++ b/Configuration/Extbase/Persistence/Classes.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types = 1);
+
+return [
+    \Featdd\DpnGlossary\Domain\Model\SimpleTerm::class => [
+        'tableName' => 'tx_dpnglossary_domain_model_term',
+    ],
+];


### PR DESCRIPTION
…ng for relations in normal Term-object

Without lazy-loading an uncached rendering of the page will process all terms and trying to resolve all ObjectStorages. Even if there is *no* entry, this causes a SQL-request. As the normal has `description` and `media` as properties, there are too avoidable SQL-request per term. For getting the terms cachable in a transient backend, lazyloading is *not* allowed due to serialization. Thus a SimpleTerm-object has been introduced without `description`, `media` and some simple properties which *is* catchable.

Fixes: #187