### PR TITLE
Fix the Webpack5 deprecation warning

### DIFF
--- a/Build/webpack.config.babel.js
+++ b/Build/webpack.config.babel.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import FixStyleOnlyEntriesPlugin from "webpack-fix-style-only-entries";
+const RemoveEmptyScripts = require("webpack-remove-empty-scripts");
 
 module.exports = {
   mode: process.env.NODE_ENV,
@@ -11,7 +11,7 @@ module.exports = {
     path: path.resolve(__dirname, './../Resources/Public'),
   },
   plugins: [
-    new FixStyleOnlyEntriesPlugin(),
+    new RemoveEmptyScripts(),
     new MiniCssExtractPlugin({
       filename: './Css/styles.css'
     })

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "sass-loader": "^13.2",
     "webpack": "^5.79",
     "webpack-cli": "^5.0",
-    "webpack-fix-style-only-entries": "^0.6.1"
+    "webpack-remove-empty-scripts": "^1.0.4"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Hello,

this project uses the outdated [webpack-fix-style-only-entries](https://github.com/fqborges/webpack-fix-style-only-entries) plugin that is incompatible with `Webpack 5`.

Using `npm run build:production` appear the deprecation warnings:
```
webpack-fix-style-only-entries:
(node:18462) [DEP_WEBPACK_CHUNK_ENTRY_MODULE] DeprecationWarning: Chunk.entryModule: Use new ChunkGraph API
(node:18462) [DEP_WEBPACK_MODULE_INDEX] DeprecationWarning: Module.index: Use new ModuleGraph API
(node:18462) [DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET] DeprecationWarning: chunk.files was changed from Array to Set (using Array method 'filter' is deprecated)
```

The author of the [webpack-fix-style-only-entries](https://github.com/fqborges/webpack-fix-style-only-entries) plugin recommends using the [webpack-remove-empty-scripts](https://github.com/webdiscus/webpack-remove-empty-scripts) plugin for Webpack 5.

This PR just replaces the outdated plugin with the actual version.
