### PR TITLE
[BUGFIX] Add url_segment to Term Model

### DIFF
--- a/Classes/Domain/Model/AbstractTerm.php
+++ b/Classes/Domain/Model/AbstractTerm.php
@@ -35,6 +35,11 @@ abstract class AbstractTerm extends AbstractEntity implements TermInterface
     /**
      * @var string
      */
+    protected string $urlSegment = '';
+
+    /**
+     * @var string
+     */
     protected string $tooltiptext = '';
 
     /**
@@ -112,6 +117,22 @@ abstract class AbstractTerm extends AbstractEntity implements TermInterface
     public function setParsingName(string $parsingName): void
     {
         $this->parsingName = $parsingName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrlSegment(): string
+    {
+        return $this->urlSegment;
+    }
+
+    /**
+     * @param string $urlSegment
+     */
+    public function setUrlSegment(string $urlSegment): void
+    {
+        $this->urlSegment = $urlSegment;
     }
 
     /**
@@ -268,6 +289,7 @@ abstract class AbstractTerm extends AbstractEntity implements TermInterface
             'pid' => $this->getPid(),
             'name' => $this->getName(),
             'parsing_name' => $this->getParsingName(),
+            'url_segment' => $this->getUrlSegment(),
             'tooltiptext' => $this->getTooltiptext(),
             'term_type' => $this->getTermType(),
             'term_lang' => $this->getTermLang(),

--- a/Classes/Domain/Model/Term.php
+++ b/Classes/Domain/Model/Term.php
@@ -181,6 +181,7 @@ class Term extends AbstractTerm
             'pid' => $this->getPid(),
             'name' => $this->getName(),
             'parsing_name' => $this->getParsingName(),
+            'url_segment' => $this->getUrlSegment(),
             'tooltiptext' => $this->getTooltiptext(),
             'term_type' => $this->getTermType(),
             'term_lang' => $this->getTermLang(),


### PR DESCRIPTION
Hi,
I just realized that the `url_segment` field is missing from the Term Domain Model. Since we need it in our case I figured this might come in handy for others too.

Seems like a little oversight to me.

regards,
R