### PR TITLE
[BUGFIX] Icon Registration

### DIFF
--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'ext-dpn_glossary-wizard-icon' => [
+        'provider' => TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:dpn_glossary/Resources/Public/Icons/Plugin_Glossary.svg',
+    ],
+    'ext-dpn_glossary-preview-wizard-icon' => [
+        'provider' => TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:dpn_glossary/Resources/Public/Icons/Plugin_Glossarypreview.svg',
+    ],
+];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,10 +7,7 @@ use Featdd\DpnGlossary\Routing\Aspect\StaticMultiRangeMapper;
 use Featdd\DpnGlossary\Updates\PluginCTypeMigrationUpdateWizard;
 use Featdd\DpnGlossary\Updates\PluginSwitchableControllerMigrationUpdateWizard;
 use Featdd\DpnGlossary\Updates\SlugUpdateWizard;
-use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
-use TYPO3\CMS\Core\Imaging\IconRegistry;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
 
 defined('TYPO3') or die();
@@ -59,21 +56,6 @@ call_user_func(
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][PluginCTypeMigrationUpdateWizard::class] = PluginCTypeMigrationUpdateWizard::class;
         $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][PluginSwitchableControllerMigrationUpdateWizard::class] = PluginSwitchableControllerMigrationUpdateWizard::class;
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['aspects']['StaticMultiRangeMapper'] = StaticMultiRangeMapper::class;
-
-        /** @var \TYPO3\CMS\Core\Imaging\IconRegistry $iconRegistry */
-        $iconRegistry = GeneralUtility::makeInstance(IconRegistry::class);
-
-        $iconRegistry->registerIcon(
-            'ext-dpn_glossary-wizard-icon',
-            SvgIconProvider::class,
-            ['source' => 'EXT:dpn_glossary/Resources/Public/Icons/Plugin_Glossary.svg']
-        );
-
-        $iconRegistry->registerIcon(
-            'ext-dpn_glossary-preview-wizard-icon',
-            SvgIconProvider::class,
-            ['source' => 'EXT:dpn_glossary/Resources/Public/Icons/Plugin_Glossarypreview.svg']
-        );
 
         if (false === isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['dpnglossary_termscache'])) {
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['dpnglossary_termscache'] = [];


### PR DESCRIPTION
use Configuration/Icons.php for register own icons Register Icons in ext_localconf.php leads to incomplete Icon Cache, because the IconRegistry constructor initialize TCA Icons before TCA is full loaded

even the tx_dpnglossary_domain_model_term is affected:

![Screenshot 2024-08-21 at 13 56 46](https://github.com/user-attachments/assets/860ded73-4c6b-463a-83eb-5ef1457ae9a1)
