### PR TITLE
[TASK] Getting ready for TYPO3 13

### DIFF
--- a/Configuration/TCA/tx_dpnglossary_domain_model_term.php
+++ b/Configuration/TCA/tx_dpnglossary_domain_model_term.php
@@ -323,50 +323,47 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:dpn_glossary/Resources/Private/Language/locallang.xlf:tx_dpnglossary_domain_model_term.media',
             'displayCond' => 'FIELD:term_mode:!=:link',
-            'config' => ExtensionManagementUtility::getFileFieldTCAConfig(
-                'media',
-                [
-                    'maxitems' => 999,
-                    'appearance' => [
-                        'createNewRelationLinkTitle' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:images.addFileReference',
-                    ],
-                    'overrideChildTca' => [
-                        'types' => [
-                            '0' => [
-                                'showitem' => '
+            'config' => [
+                'type' => 'file',
+                'allowed' => 'common-image-types',
+                'appearance' => [
+                    'createNewRelationLinkTitle' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:images.addFileReference',
+                ],
+                'overrideChildTca' => [
+                    'types' => [
+                        '0' => [
+                            'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette',
-                            ],
-                            AbstractFile::FILETYPE_TEXT => [
-                                'showitem' => '
+                        ],
+                        AbstractFile::FILETYPE_TEXT => [
+                            'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette',
-                            ],
-                            AbstractFile::FILETYPE_IMAGE => [
-                                'showitem' => '
+                        ],
+                        AbstractFile::FILETYPE_IMAGE => [
+                            'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette',
-                            ],
-                            AbstractFile::FILETYPE_AUDIO => [
-                                'showitem' => '
+                        ],
+                        AbstractFile::FILETYPE_AUDIO => [
+                            'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette',
-                            ],
-                            AbstractFile::FILETYPE_VIDEO => [
-                                'showitem' => '
+                        ],
+                        AbstractFile::FILETYPE_VIDEO => [
+                            'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette',
-                            ],
-                            AbstractFile::FILETYPE_APPLICATION => [
-                                'showitem' => '
+                        ],
+                        AbstractFile::FILETYPE_APPLICATION => [
+                            'showitem' => '
                             --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,
                             --palette--;;filePalette',
-                            ],
                         ],
                     ],
                 ],
-                $GLOBALS['TYPO3_CONF_VARS']['SYS']['mediafile_ext']
-            ),
+            ],
         ],
         'seo_title' => [
             'exclude' => true,

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
     "GPL-2.0-or-later"
   ],
   "require": {
-    "typo3/cms-core": "~11.5||~12.4",
-    "php": ">=8.0 <8.4",
+    "typo3/cms-core": "^12.4||^13.4",
+    "php": ">=8.1 <8.4",
     "ext-dom": "*",
     "ext-libxml": "*",
     "ext-pdo": "*"


### PR DESCRIPTION
This version of dpn glossary is installable in TYPO3 13 and prevents errors when opening the frontend

Related: https://github.com/featdd/dpn_glossary/issues/225