### PR TITLE
[BUGFIX] Prevent TypeError when storagePid is empty

### DIFF
--- a/Classes/Service/ParserService.php
+++ b/Classes/Service/ParserService.php
@@ -155,7 +155,7 @@ class ParserService implements SingletonInterface
                     $termsCache->set($cacheIdentifier, $terms, [
                         ...array_map(
                             fn(int $storagePid) => sprintf('storage-%d', $storagePid),
-                            $querySettings->getStoragePageIds()
+                            array_map('intval', $querySettings->getStoragePageIds())
                         ),
                         sprintf('language-%d', $languageId),
                     ]);


### PR DESCRIPTION
When `plugin.tx_dpnglossary.persistence.storagePid` is not set, `getStoragePageIds()` may return an array with an empty string. Passing this value into the cache tag generation caused a TypeError in the ParserService.

The storage PIDs are now normalized to integers before formatting, so empty or invalid values become `0`. This prevents runtime errors and ensures deterministic cache tags (`storage-0` as fallback).

Resolves: #239