### PR TITLE
Add extension title to composer.json description (TYPO3 v14 #108304)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "featdd/dpn-glossary",
   "type": "typo3-cms-extension",
-  "description": "Glossary extension with page parser",
+  "description": "dreipunktnull Glossar - Glossary extension with page parser",
   "homepage": "https://extensions.typo3.org/extension/dpn_glossary",
   "license": [
     "GPL-2.0-or-later"


### PR DESCRIPTION
Since TYPO3 v14, the extension title is read from the composer.json `description` field instead of `ext_emconf.php` (breaking change #108304). The part before the first ` - ` (space-dash-space) is used as the title, the remainder as the description.

Currently `dpn_glossary` has no ` - ` separator in its composer description, so in Composer mode the extension shows with its full description as title instead of "dreipunktnull Glossar" (the title from ext_emconf.php). This also triggers the "Extension title not set correctly in composer.json" warning in the backend status report.

This PR prepends the existing ext_emconf.php title accordingly. No functional change.

Ref: https://docs.typo3.org/permalink/changelog:breaking-108304-1764058005